### PR TITLE
Improve folding regions with elif/else blocks

### DIFF
--- a/jinja2.xml
+++ b/jinja2.xml
@@ -43,6 +43,11 @@
     <item>autoescape</item>
 </list>
 
+<list name="blockdividers">
+    <item>else</item>
+    <item>elif</item>
+</list>
+
 <list name="endblocktags">
     <item>end</item> <!-- jinja-simplesyntax extension -->
     <item>endfor</item>
@@ -83,6 +88,7 @@
 <context name="Block" attribute="Normal Text" lineEndContext="#stay">
     <Detect2Chars attribute="Block delimiter" context="#pop#pop" char="%" char1="}" />
     <keyword context="#stay" attribute="Keyword" String="keywords" />
+    <keyword context="#stay" attribute="Keyword" String="blockdividers" endRegion="jinjablock" beginRegion="jinjablock" />
     <keyword context="#stay" attribute="Keyword" String="blocktags" beginRegion="jinjablock" />
     <keyword context="#stay" attribute="Keyword" String="endblocktags" endRegion="jinjablock" />
     <IncludeRules context="##Python" />
@@ -90,6 +96,7 @@
 
 <context name="LineStatement" attribute="Normal Text" lineEndContext="#pop#pop">
     <keyword context="#stay" attribute="Keyword" String="keywords" />
+    <keyword context="#stay" attribute="Keyword" String="blockdividers" endRegion="jinjablock" beginRegion="jinjablock" />
     <keyword context="#stay" attribute="Keyword" String="blocktags" beginRegion="jinjablock" />
     <keyword context="#stay" attribute="Keyword" String="endblocktags" endRegion="jinjablock" />
     <IncludeRules context="##Python" />

--- a/tests/template.html
+++ b/tests/template.html
@@ -26,7 +26,26 @@ body{
 
 <body>
 
-{% block content %}{% endblock %}
+{% block content %}
+
+
+    {% if True %}
+        A
+    {% elif False %}
+        B
+    {% elif False %}
+        {% if False %}
+            C
+        {% else %}
+            D
+        {% endif %}
+        E
+    {% else %}
+        F
+    {% endif %}
+
+
+{% endblock %}
 
 </body>
 </html>

--- a/tests/template.jinja
+++ b/tests/template.jinja
@@ -4,9 +4,33 @@
 
 {% block content %}
 
+    {% for i in range(100) %}
+        {% if i == 12 %}
+            {{ i }}
+        {% elif i == 4 %}
+            {{ i + 1 }}
+        {% else %}
+            {{ i }}
+        {% endif %}
+    {% endfor %}
+
+
     %:for i in range(100):
         %:if i == 12:
             {{ i }}
+        %:elif i == 4:
+            {{ i + 1 }}
+        %:else:
+            {{ i }}
+        %:endif
+    %:endfor
+
+
+    %:for i in range(100):
+        %:if i == 12:
+            {{ i }}
+        %:elif i == 4:
+            {{ i + 1 }}
         %:else:
             {{ i }}
         %:end


### PR DESCRIPTION
Fixes an issue where the folding regions for elif/else block
was not ended correctly, causing the region to continue to
the end of the document.

Fixes issue #9